### PR TITLE
Bug fix upload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ yarn @mainframework/dropzone
 `Hook config properties`
 {
 maximumUploadCount:5, //Defaults to 30
-maximumFileSize = maxFileSize, //Defaults to 10 mb's
+maximumFileSize = maxFileSize, //Defaults to 5 mb's
 acceptedTypes = defaultTypeExtensions, //See the default extensions above
 }
 
@@ -68,8 +68,9 @@ export const defaultTypeExtensions: Record<string, string> = {
 ```JS | TS
 //Here you can set the following properties for the FileSelector.  These are all optional
  const { validFiles, onIdChange, onCancel, onRemoveFile, FileSelector } = useFileSelector({
+  acceptTypes: ".png" //Defaults to ".png, .jpg, .jpeg, .pdf, .svg, image/svg+xml, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   maximumUploadCount:5,  //Defaults to 30
-  maximumFileSize = maxFileSize,  //Defaults to 10 mb's
+  maximumFileSize = 5e6,  //Defaults to 5 mb's
   acceptedTypes = defaultTypeExtensions,  //See the default extensions above
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainframework/dropzone",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A file selection package, without all of the re-rendering issues that come with other dropzone packages",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/shared/components/FileSelector/FileSelector.tsx
+++ b/src/shared/components/FileSelector/FileSelector.tsx
@@ -2,8 +2,11 @@ import { RefCallback, useEffect, useRef, MouseEvent } from "react";
 import { FileSelectorProps } from "../../types/types";
 
 import "./tailwind.css";
+const defaultAcceptTypes =
+  ".png, .jpg, .jpeg, .pdf, .svg, image/svg+xml, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 export const FileSelector = ({
   inputId,
+  acceptTypes,
   messageParagraph,
   inputClassName,
   clickableAreaClassName,
@@ -78,7 +81,7 @@ export const FileSelector = ({
         type="file"
         className={inputClassesRef.current}
         onChange={onChange}
-        accept=".png, .jpg, .jpeg, .pdf, .svg, image/svg+xml, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        accept={acceptTypes ?? defaultAcceptTypes}
         multiple
       />
     </div>

--- a/src/shared/hooks/useFileSelector.tsx
+++ b/src/shared/hooks/useFileSelector.tsx
@@ -16,6 +16,7 @@ import { useCustomCallback } from "./useCustomCallback";
 import { FileSelector } from "../components/FileSelector";
 
 export const useFileSelector = ({
+  acceptTypes,
   maximumUploadCount = maxUploadCount,
   maximumFileSize = maxFileSize,
   acceptedTypes = defaultTypeExtensions,
@@ -191,6 +192,7 @@ export const useFileSelector = ({
 
   const FileSelectorRef = useRef(() => (
     <FileSelector
+      acceptTypes={acceptTypes}
       onChange={onInputChange}
       onDragOver={onDragOver}
       onDrop={onDrop}

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -2,6 +2,7 @@ import { ChangeEvent, DragEvent } from "react";
 
 export interface FileSelectorProps {
   inputId?: string;
+  acceptTypes?: string;
   messageParagraph?: string;
   inputClassName?: string;
   clickableAreaClassName?: string;
@@ -16,6 +17,7 @@ export interface FileSelectorProps {
 
 //Incoming Props
 export interface IFileUploaderProps {
+  acceptTypes?: string;
   maximumUploadCount?: number;
   maximumFileSize?: number;
   acceptedTypes?: Record<string, string>;

--- a/src/shared/utils/processUploadedFiles.ts
+++ b/src/shared/utils/processUploadedFiles.ts
@@ -13,7 +13,7 @@ export const defaultTypeExtensions: Record<string, string> = {
 //This is the attribute that should be present in all svg files
 const xmlns = "<svg xmlns='http://www.w3.org/2000/svg' ";
 export const maximumUploadCount = 30;
-export const maximumFileSize = 1e6; //5e6; //5 mb's
+export const maximumFileSize = 5e6; //5 mb's
 export const printableMaximumFileSize = "5 Megabytes";
 
 export const isValidFileType = (file: File, acceptedTypes = defaultTypeExtensions) => Boolean(acceptedTypes[file.type]);


### PR DESCRIPTION
Fixed default file uploading size
Removed css for the body
updated the css for the hidden input.  Wasn't applying the tailwindcss hidden class
added acceptTypes as a prop in the hook and fileselctor component